### PR TITLE
fix: lane boundaries without z-values

### DIFF
--- a/common/utils/marker.ts
+++ b/common/utils/marker.ts
@@ -4,7 +4,6 @@ import {
   CubePrimitive,
   Color,
   Point3,
-  Point2,
   ModelPrimitive,
   Vector3,
 } from "@foxglove/schemas";
@@ -20,7 +19,7 @@ export interface ArrowProperties {
 }
 
 export function pointListToLinePrimitive(
-  points: Point2[],
+  points: Point3[],
   thickness: number,
   color: Color,
 ): LinePrimitive {
@@ -33,7 +32,7 @@ export function pointListToLinePrimitive(
     thickness,
     scale_invariant: false,
     points: points.map((p) => {
-      return { x: p.x, y: p.y, z: 0.0 };
+      return { x: p.x, y: p.y, z: p.z };
     }),
     color,
     colors: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import {
   type LinePrimitive,
   type Point3,
   type Quaternion,
-  type Vector2,
   type Vector3,
 } from "@foxglove/schemas";
 import { Time } from "@foxglove/schemas/schemas/typescript/Time";
@@ -146,10 +145,6 @@ function buildLaneBoundaryEntity(
   frame_id: string,
   time: Time,
 ): PartialSceneEntity {
-  const boundaryPoints = osiLaneBoundary.boundary_line.map(
-    (point) => ({ x: point.position.x, y: point.position.y }) as Vector2,
-  );
-
   const color = LANE_BOUNDARY_COLOR[osiLaneBoundary.classification.type];
   let line: LinePrimitive;
   switch (osiLaneBoundary.classification.type) {
@@ -173,7 +168,7 @@ function buildLaneBoundaryEntity(
       break;
     default:
       line = pointListToLinePrimitive(
-        boundaryPoints,
+        osiLaneBoundary.boundary_line.map((point) => point.position as Vector3),
         osiLaneBoundary.boundary_line[0]?.width ?? 0,
         color,
       );


### PR DESCRIPTION
- [x] write one LanePrimitive function with optional parameters -> mved to #66 