### PR TITLE
Fix/infinite object lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # ASAM OSI Converter version history
 
+## [0.0.5](https://github.com/Lichtblick-Suite/asam-osi-converter/compare/v0.0.4...v0.0.5) (2025-03-07)
+
+
+### Features
+
+* add lane boundary and lane implementation including color schema and temporary caching ([#81](https://github.com/Lichtblick-Suite/asam-osi-converter/issues/81)) ([4c9cc52](https://github.com/Lichtblick-Suite/asam-osi-converter/commit/4c9cc526a1c8449ed0a42314e1fb3b928bed17f8))
+
+
+
 ## [0.0.4](https://github.com/Lichtblick-Suite/asam-osi-converter/compare/v0.0.3...v0.0.4) (2025-02-15)
+
 
 ### Bug Fixes
 
@@ -9,20 +19,27 @@
 * rotation angles ([#64](https://github.com/Lichtblick-Suite/asam-osi-converter/issues/64)) ([fb017e1](https://github.com/Lichtblick-Suite/asam-osi-converter/commit/fb017e14f762dec4e73ae5fe8e93081768bdfb1f))
 * split up and fix frame transforms, increase robustness ([#72](https://github.com/Lichtblick-Suite/asam-osi-converter/issues/72)) ([6e082a1](https://github.com/Lichtblick-Suite/asam-osi-converter/commit/6e082a152e6cdaa62dd9efbae550d0264c0e56fd))
 
+
+
 ## [0.0.3](https://github.com/Lichtblick-Suite/asam-osi-converter/compare/v0.0.2...v0.0.3) (2024-12-17)
+
 
 ### Bug Fixes
 
 * **ci:** release pipeline fix ([#25](https://github.com/Lichtblick-Suite/asam-osi-converter/issues/25)) ([b34e891](https://github.com/Lichtblick-Suite/asam-osi-converter/commit/b34e891568e6d892e3f1b03029bafae6723a4fbf))
 
+
+
 ## [0.0.2](https://github.com/Lichtblick-Suite/asam-osi-converter/compare/v0.0.1...v0.0.2) (2024-12-12)
+
 
 ### Features
 
 * **CI/CD:** automate changelog creation and update ([#18](https://github.com/Lichtblick-Suite/asam-osi-converter/issues/18)) ([c511ba0](https://github.com/Lichtblick-Suite/asam-osi-converter/commit/c511ba061a30faf861d447ca71bff094c6b77532))
 
-## 0.0.1 (2024-10-18)
 
+
+## 0.0.1 (2024-10-18)
 Initial commit
 
 Update LICENSE

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,16 +455,23 @@ function buildSceneEntities(
   if (updateFlags.movingObjects) {
     movingObjectSceneEntities = osiGroundTruth.moving_object.map((obj) => {
       let entity;
+      let metadata = [
+        {
+          key: "moving_object_type",
+          value: MovingObject_Type[obj.type],
+        },
+      ];
       if (obj.id.value === osiGroundTruth.host_vehicle_id?.value) {
-        const metadata = buildVehicleMetadata(obj.vehicle_classification);
+        metadata = [...metadata, ...buildVehicleMetadata(obj.vehicle_classification)];
         entity = buildObjectEntity(obj, HOST_OBJECT_COLOR, ROOT_FRAME, time, metadata);
       } else {
         //const objectType = MovingObject_Type[obj.type];
         const objectColor = MOVING_OBJECT_COLOR[obj.type];
-        const metadata =
+        const vehicleMetadata =
           obj.type === MovingObject_Type.VEHICLE
             ? buildVehicleMetadata(obj.vehicle_classification)
             : [];
+        metadata = [...metadata, ...vehicleMetadata];
         entity = buildObjectEntity(obj, objectColor, ROOT_FRAME, time, metadata);
       }
       return entity;

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,12 +70,28 @@ import { preloadDynamicTextures, buildTrafficSignModel } from "./trafficsigns";
 const ROOT_FRAME = "<root>";
 
 // Object-specific prefixes for scene entity ids
-const PREFIX_MOVING_OBJECT = "moving_object_";
-const PREFIX_STATIONARY_OBJECT = "stationary_object_";
-const PREFIX_LANE_BOUNDARY = "lane_boundary_";
-const PREFIX_LANE = "lane_";
-const PREFIX_TRAFFIC_SIGN = "traffic_sign_";
-const PREFIX_TRAFFIC_LIGHT = "traffic_light_";
+const PREFIX_MOVING_OBJECT = "moving_object";
+const PREFIX_STATIONARY_OBJECT = "stationary_object";
+const PREFIX_LANE_BOUNDARY = "lane_boundary";
+const PREFIX_LANE = "lane";
+const PREFIX_TRAFFIC_SIGN = "traffic_sign";
+const PREFIX_TRAFFIC_LIGHT = "traffic_light";
+
+/**
+ * Generates a unique scene entity ID by combining a predefined object-type-specific prefix
+ * with the given numeric ID.
+ *
+ * This function, together with the predefined object-type-specific prefixes,
+ * must be used when creating scene entity IDs to ensure consistency and uniqueness
+ * across different entity types.
+ *
+ * @param prefix - The object-type-specific prefix to prepend to the ID.
+ * @param id - The numeric ID of the entity.
+ * @returns A string representing the unique scene entity ID.
+ */
+function generateSceneEntityId(prefix: string, id: number): string {
+  return `${prefix}_${id.toString()}`;
+}
 
 function buildObjectEntity(
   osiObject: DeepRequired<MovingObject> | DeepRequired<StationaryObject>,
@@ -101,7 +117,7 @@ function buildObjectEntity(
   return {
     timestamp: time,
     frame_id,
-    id: id_prefix + osiObject.id.value.toString(),
+    id: generateSceneEntityId(id_prefix, osiObject.id.value),
     lifetime: { sec: 0, nsec: 0 },
     frame_locked: true,
     cubes: [cube],
@@ -129,7 +145,7 @@ function buildTrafficSignEntity(
   return {
     timestamp: time,
     frame_id,
-    id: id_prefix + obj.id.value.toString(),
+    id: generateSceneEntityId(id_prefix, obj.id.value),
     lifetime: { sec: 0, nsec: 0 },
     frame_locked: true,
     // texts,
@@ -152,7 +168,7 @@ function buildTrafficLightEntity(
   return {
     timestamp: time,
     frame_id,
-    id: id_prefix + obj.id.value.toString(),
+    id: generateSceneEntityId(id_prefix, obj.id.value),
     lifetime: { sec: 0, nsec: 0 },
     frame_locked: true,
     // texts,
@@ -199,7 +215,7 @@ function buildLaneBoundaryEntity(
   return {
     timestamp: time,
     frame_id,
-    id: PREFIX_LANE_BOUNDARY + osiLaneBoundary.id.value.toString(),
+    id: generateSceneEntityId(PREFIX_LANE_BOUNDARY, osiLaneBoundary.id.value),
     lifetime: { sec: 0, nsec: 0 },
     frame_locked: true,
     triangles: [pointListToTriangleListPrimitive(laneBoundaryPoints, color, options)],
@@ -275,7 +291,7 @@ function buildLaneEntity(
   return {
     timestamp: time,
     frame_id,
-    id: PREFIX_LANE + osiLane.id.value.toString(),
+    id: generateSceneEntityId(PREFIX_LANE, osiLane.id.value),
     lifetime: { sec: 0, nsec: 0 },
     frame_locked: true,
     triangles: [
@@ -710,7 +726,7 @@ function getDeletedEntities<T extends { id: { value: number } }>(
   previousFrameIds.clear();
   currentIds.forEach((id) => previousFrameIds.add(id));
   return deletedIds.map((id) => ({
-    id: `${entityPrefix}${id.toString()}`,
+    id: generateSceneEntityId(entityPrefix, id),
     timestamp,
     type: SceneEntityDeletionType.MATCHING_ID,
   }));


### PR DESCRIPTION
Currently the extension uses infinite object lifetime for all object types which contradicts the "complete snapshot" paradigm of OSI. This means that objects remain displayed even if they (intentionally) disappear in some later frame of an OSI trace (e.g. because of ground truth chunking or disappearing sensor data objects).

This PR adds the following changes:

- Compares object ids of previously called frame and current frame to find disappeared objects
- Adds scene entity deletions for the disappeared objects
- Aligned scene entity ids with OSI ids for moving and stationary objects
  Note: The object type prefix (e.g. "moving_object_VEHICLE_") is no longer part of the scene entity id. OSI ids are required to be unique across all object types anyways and this makes it a lot more lightweight to check for deletions between frames.
- Added info on moving object type to metadata