### PR TITLE
feat: add additional metadata for moving objects 2

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -8,7 +8,6 @@ import {
   LaneBoundary_Classification_Type,
   MovingObject,
   MovingObject_Type,
-  MovingObject_VehicleClassification,
   MovingObject_VehicleClassification_LightState_BrakeLightState,
   MovingObject_VehicleClassification_LightState_GenericLightState,
   MovingObject_VehicleClassification_LightState_IndicatorState,
@@ -18,7 +17,7 @@ import {
 import { ExtensionContext } from "@lichtblick/suite";
 import { DeepRequired } from "ts-essentials";
 
-import { activate, buildVehicleMetadata } from "../index";
+import { activate, buildMovingObjectMetadata } from "../index";
 import { buildLaneBoundaryMetadata } from "../lanes";
 
 jest.mock(
@@ -51,14 +50,43 @@ describe("OSI Visualizer: Message Converter", () => {
       roll: 0,
     },
   };
+  const mockBaseMoving = {
+    dimension: {
+      width: 1,
+      height: 1,
+      length: 1,
+    },
+    position: {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
+    acceleration: {
+      x: 20,
+      y: 20,
+      z: 0,
+    },
+    velocity: {
+      x: 30,
+      y: 40,
+      z: 0,
+    },
+    orientation: {
+      yaw: 0,
+      pitch: 0,
+      roll: 0,
+    },
+  };
   const mockMovingObject = {
     id: {
       value: 0,
     },
-    base: mockBase,
+    base: mockBaseMoving,
     type: {
       value: MovingObject_Type.VEHICLE,
     },
+    assigned_lane_id: [99, 100],
+    model_reference: "",
     vehicle_attributes: {
       bbcenter_to_rear: {
         x: 0,
@@ -186,40 +214,73 @@ describe("OSI Visualizer: Message Converter", () => {
 });
 
 describe("OSI Visualizer: Moving Objects", () => {
-  it("builds metadata  for vehicle moving objects", () => {
-    const input = {
+  const input = {
+    type: MovingObject_Type.VEHICLE,
+    base: {
+      acceleration: {
+        x: 20,
+        y: 20,
+        z: 0,
+      },
+      velocity: {
+        x: 30,
+        y: 40,
+        z: 0,
+      },
+    },
+    assigned_lane_id: [{ value: 99 }, { value: 100 }],
+    vehicle_classification: {
       type: 5,
       light_state: {
         indicator_state: 5,
         brake_light_state: 4,
         head_light: 3,
       },
-    } as DeepRequired<MovingObject_VehicleClassification>;
-    expect(buildVehicleMetadata(input)).toEqual(
+    },
+  } as unknown as DeepRequired<MovingObject>;
+
+  it("builds metadata  for vehicle moving objects", () => {
+    expect(buildMovingObjectMetadata(input)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          key: "moving_object_type",
+          value: MovingObject_Type[input.type],
+        }),
+        expect.objectContaining({
+          key: "acceleration",
+          value: `${input.base.acceleration.x}, ${input.base.acceleration.y}, ${input.base.acceleration.z}`,
+        }),
+        expect.objectContaining({
+          key: "velocity",
+          value: `${input.base.velocity.x}, ${input.base.velocity.y}, ${input.base.velocity.z}`,
+        }),
+        expect.objectContaining({
+          key: "assigned_lane_id",
+          value: input.assigned_lane_id.map((id) => id.value).join(","),
+        }),
+        expect.objectContaining({
           key: "type",
-          value: MovingObject_VehicleClassification_Type[input.type],
+          value: MovingObject_VehicleClassification_Type[input.vehicle_classification.type],
         }),
         expect.objectContaining({
           key: "light_state.indicator_state",
           value:
             MovingObject_VehicleClassification_LightState_IndicatorState[
-              input.light_state.indicator_state
+              input.vehicle_classification.light_state.indicator_state
             ],
         }),
         expect.objectContaining({
           key: "light_state.brake_light_state",
           value:
             MovingObject_VehicleClassification_LightState_BrakeLightState[
-              input.light_state.brake_light_state
+              input.vehicle_classification.light_state.brake_light_state
             ],
         }),
         expect.objectContaining({
           key: "light_state.head_light",
           value:
             MovingObject_VehicleClassification_LightState_GenericLightState[
-              input.light_state.head_light
+              input.vehicle_classification.light_state.head_light
             ],
         }),
       ]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import {
   LaneBoundary_BoundaryPoint,
   MovingObject,
   MovingObject_Type,
-  MovingObject_VehicleClassification,
   MovingObject_VehicleClassification_Type,
   SensorData,
   SensorView,
@@ -369,23 +368,45 @@ const lightStateEnumStringMaps: IlightStateEnumStringMaps = {
   generic_light_state: MovingObject_VehicleClassification_LightState_GenericLightState,
 };
 
-export function buildVehicleMetadata(
-  vehicle_classification: DeepRequired<MovingObject_VehicleClassification>,
+export function buildMovingObjectMetadata(
+  moving_object: DeepRequired<MovingObject>,
 ): KeyValuePair[] {
-  return [
+  const metadata: KeyValuePair[] = [
+    { key: "moving_object_type", value: MovingObject_Type[moving_object.type] },
     {
-      key: "type",
-      value: MovingObject_VehicleClassification_Type[vehicle_classification.type],
+      key: "acceleration",
+      value: `${moving_object.base.acceleration.x}, ${moving_object.base.acceleration.y}, ${moving_object.base.acceleration.z}`,
     },
-    ...Object.entries(vehicle_classification.light_state ?? {}).map(([key, value]) => {
-      return {
-        key: `light_state.${key}`,
-        value:
-          lightStateEnumStringMaps[key]?.[value] ??
-          lightStateEnumStringMaps.generic_light_state[value]!,
-      };
-    }),
+    {
+      key: "velocity",
+      value: `${moving_object.base.velocity.x}, ${moving_object.base.velocity.y}, ${moving_object.base.velocity.z}`,
+    },
+    {
+      key: "assigned_lane_id",
+      value:
+        moving_object.assigned_lane_id.length > 0
+          ? moving_object.assigned_lane_id.map((id) => id.value).join(",")
+          : "",
+    },
   ];
+
+  if (moving_object.type === MovingObject_Type.VEHICLE) {
+    metadata.push(
+      {
+        key: "type",
+        value: MovingObject_VehicleClassification_Type[moving_object.vehicle_classification.type],
+      },
+      ...Object.entries(moving_object.vehicle_classification.light_state).map(([key, value]) => {
+        return {
+          key: `light_state.${key}`,
+          value:
+            lightStateEnumStringMaps[key]?.[value] ??
+            lightStateEnumStringMaps.generic_light_state[value]!,
+        };
+      }),
+    );
+  }
+  return metadata;
 }
 
 export function buildStationaryMetadata(obj: DeepRequired<StationaryObject>): KeyValuePair[] {
@@ -489,12 +510,7 @@ function buildSceneEntities(
   if (updateFlags.movingObjects) {
     movingObjectSceneEntities = osiGroundTruth.moving_object.map((obj) => {
       let entity;
-      let metadata = [
-        {
-          key: "moving_object_type",
-          value: MovingObject_Type[obj.type],
-        },
-      ];
+      const metadata = buildMovingObjectMetadata(obj);
 
       const modelPathKey = config?.defaultModelPath + obj.model_reference;
       if (
@@ -506,7 +522,6 @@ function buildSceneEntities(
       }
 
       if (obj.id.value === osiGroundTruth.host_vehicle_id.value) {
-        metadata = [...metadata, ...buildVehicleMetadata(obj.vehicle_classification)];
         entity = buildObjectEntity(
           obj,
           HOST_OBJECT_COLOR,
@@ -518,13 +533,7 @@ function buildSceneEntities(
           metadata,
         );
       } else {
-        //const objectType = MovingObject_Type[obj.type];
         const objectColor = MOVING_OBJECT_COLOR[obj.type];
-        const vehicleMetadata =
-          obj.type === MovingObject_Type.VEHICLE
-            ? buildVehicleMetadata(obj.vehicle_classification)
-            : [];
-        metadata = [...metadata, ...vehicleMetadata];
         entity = buildObjectEntity(
           obj,
           objectColor,


### PR DESCRIPTION
- Added additional metadata (velocity, acceleration, lane-assignement) for moving object.
- Added a unit test
- Fixed previous runtime error (undefined length)

The following shows a metadata panel for a pedestrian and a vehicle:
<img width="281" height="295" alt="image" src="https://github.com/user-attachments/assets/f490e330-fa6b-4a5c-84ec-a94d9d39ba17" />
<img width="273" height="127" alt="image" src="https://github.com/user-attachments/assets/27cc56f8-3c7b-4e31-b5fe-82fb6350af2c" />
