### PR TITLE
use new assigned_lane_id instead of deprecated one

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -85,7 +85,6 @@ describe("OSI Visualizer: Message Converter", () => {
     type: {
       value: MovingObject_Type.VEHICLE,
     },
-    assigned_lane_id: [99, 100],
     model_reference: "",
     vehicle_attributes: {
       bbcenter_to_rear: {
@@ -93,6 +92,9 @@ describe("OSI Visualizer: Message Converter", () => {
         y: 0,
         z: 0,
       },
+    },
+    moving_object_classification: {
+      assigned_lane_id: [99, 100],
     },
     vehicle_classification: {
       type: {
@@ -228,7 +230,9 @@ describe("OSI Visualizer: Moving Objects", () => {
         z: 0,
       },
     },
-    assigned_lane_id: [{ value: 99 }, { value: 100 }],
+    moving_object_classification: {
+      assigned_lane_id: [99, 100],
+    },
     vehicle_classification: {
       type: 5,
       light_state: {
@@ -256,7 +260,9 @@ describe("OSI Visualizer: Moving Objects", () => {
         }),
         expect.objectContaining({
           key: "assigned_lane_id",
-          value: input.assigned_lane_id.map((id) => id.value).join(","),
+          value: input.moving_object_classification.assigned_lane_id
+            .map((id) => id.value)
+            .join(","),
         }),
         expect.objectContaining({
           key: "type",

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,8 +384,10 @@ export function buildMovingObjectMetadata(
     {
       key: "assigned_lane_id",
       value:
-        moving_object.assigned_lane_id.length > 0
-          ? moving_object.assigned_lane_id.map((id) => id.value).join(",")
+        moving_object.moving_object_classification.assigned_lane_id.length > 0
+          ? moving_object.moving_object_classification.assigned_lane_id
+              .map((id) => id.value)
+              .join(",")
           : "",
     },
   ];


### PR DESCRIPTION
We need to use **osi3::MovingObject::MovingObjectClassification::assigned_lane_id** instead of **osi3::MovingObject::assigned_lane_id** because it is deprecated.