### PR TITLE
chore(deps): patch brace-expansion ReDoS vulnerabilities

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,17 +1852,17 @@ baseline-browser-mapping@^2.9.0:
   integrity sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz"
+  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary

Patches `brace-expansion` to fix 18 moderate-severity ReDoS vulnerabilities.

## Changes

Lockfile-only update — no code or `package.json` changes:

| Package | Before | After | Vulns fixed |
|---------|--------|-------|-------------|
| `brace-expansion` (v1 tree) | 1.1.12 | 1.1.13 | 12 moderate |
| `brace-expansion` (v5 tree) | 5.0.4 | 5.0.5 | 6 moderate |

Both are **patch-level bumps** with no breaking changes — they only fix the zero-step sequence ReDoS vector.

## Audit result

| Metric | Before | After |
|--------|--------|-------|
| Total vulnerabilities | 19 | **1** |
| Moderate | 18 | **0** |
| Low | 1 | 1 (blocked on jest@30, see #181) |

## Verification

- ✅ `yarn install --frozen-lockfile` — succeeds
- ✅ `yarn build` — succeeds
- ✅ `yarn test` — 68/68 tests pass
- ✅ `yarn audit` — 1 low-severity finding (only remaining)