### PR TITLE
fix(ci): use PAT_TOKEN for tag push in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git"
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 


### PR DESCRIPTION
## Problem

The release workflow fails with a 403 when triggered via `workflow_dispatch`. The "Create and push tag" step uses the default `GITHUB_TOKEN` from `actions/checkout`, which lacks push permission to create and push tags.

**Failed run:** https://github.com/lichtblick-suite/asam-osi-converter/actions/runs/25326002385

```
remote: Permission to lichtblick-suite/asam-osi-converter.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/lichtblick-suite/asam-osi-converter.git/': The requested URL returned error: 403
```

## Fix

Authenticate the git remote with `PAT_TOKEN` before pushing the tag — the same pattern already used later in the workflow for the changelog commit (line 76).

## Changes

- Added `git remote set-url origin` with `PAT_TOKEN` to the "Create and push tag" step

## Testing

This is a CI-only change. Verification requires re-running the `workflow_dispatch` release trigger after merge.