### PR TITLE
fix(ci): add persist-credentials: false to unblock PAT push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Extract and validate version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git"
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 


### PR DESCRIPTION
## Problem

The release workflow fails at the "Create and push tag" step with:
```
remote: Permission to lichtblick-suite/asam-osi-converter.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

## Root Cause

Commit 4bc1423 removed `token: ${{ secrets.PAT_TOKEN }}` from the `actions/checkout@v4` step to prevent a workflow trigger loop. However, the checkout still stores an `http.extraheader` git config with the default `GITHUB_TOKEN`. This extraheader **overrides** the PAT credentials set later via `git remote set-url`, so pushes still use the unprivileged token.

## Fix

Add `persist-credentials: false` to the checkout step. This prevents the default token's extraheader from being stored, allowing the explicit `git remote set-url` with `PAT_TOKEN` to take effect for tag and changelog pushes.

## Testing

- `yarn lint:ci` ✅ (no source changes)
- Verified against GitHub Actions checkout docs that `persist-credentials: false` disables extraheader storage