### PR TITLE
fix(ci): remove push tag trigger to prevent release loop

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: release
 
 on:
-  push:
-    tags: ["v[0-9].[0-9]+.[0-9]+"]
   workflow_dispatch:
     inputs:
       confirm:
@@ -29,31 +27,19 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            pushed_tag="${{ github.ref_name }}"
-            if [ "${pushed_tag}" != "${tag}" ]; then
-              echo "::error::Pushed tag '${pushed_tag}' does not match package.json version '${tag}'"
-              exit 1
-            fi
-            echo "✅ Tag '${tag}' matches package.json version"
+          confirm="${{ github.event.inputs.confirm }}"
+          confirm="${confirm#v}"
+          if [ "${confirm}" != "${version}" ]; then
+            echo "::error::Confirmation input '${confirm}' does not match package.json version '${version}'"
+            exit 1
           fi
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            confirm="${{ github.event.inputs.confirm }}"
-            confirm="${confirm#v}"
-            if [ "${confirm}" != "${version}" ]; then
-              echo "::error::Confirmation input '${confirm}' does not match package.json version '${version}'"
-              exit 1
-            fi
-            if git ls-remote --tags origin | grep -q "refs/tags/${tag}$"; then
-              echo "::error::Tag '${tag}' already exists on remote. Bump the version in package.json first."
-              exit 1
-            fi
-            echo "✅ Version '${version}' confirmed, tag '${tag}' does not exist yet"
+          if git ls-remote --tags origin | grep -q "refs/tags/${tag}$"; then
+            echo "::error::Tag '${tag}' already exists on remote. Bump the version in package.json first."
+            exit 1
           fi
+          echo "✅ Version '${version}' confirmed, tag '${tag}' does not exist yet"
 
       - name: Create and push tag
-        if: github.event_name == 'workflow_dispatch'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

The release workflow enters an infinite loop:
1. `workflow_dispatch` → pushes tag `v1.0.0` using `PAT_TOKEN`
2. PAT-triggered events create new workflow runs → matches `push: tags` trigger
3. New run executes → `automatic-releases-with-sha-action` updates the tag with PAT → re-triggers again
4. Loop repeats indefinitely (~10 runs observed for v1.0.0)

## Root Cause

The workflow triggers on both `workflow_dispatch` and `push: tags`. Since `PAT_TOKEN` is used (not `GITHUB_TOKEN`), tag pushes trigger new workflow runs. `GITHUB_TOKEN` events don't trigger workflows, but PAT events do.

## Fix

Remove the `push: tags` trigger entirely, matching the pattern used by [asam-osi-utilities](https://github.com/lichtblick-suite/asam-osi-utilities/blob/main/.github/workflows/cd_release.yml). The `workflow_dispatch` trigger already handles tag creation, making the push trigger redundant.

Also simplifies the version validation step by removing the now-dead `push` event code path.

## Testing

- Workflow syntax validated
- Compared against working reference: `lichtblick-suite/asam-osi-utilities`