### PR TITLE
fix(ci): use git-cliff and gh release for changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,9 +53,13 @@ jobs:
           git pull origin main
 
       - name: Generate changelog for this release
-        uses: janheinrichmerker/action-github-changelog-generator@v2.4
+        uses: orhun/git-cliff-action@v4
         with:
-          token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }} 
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_TOKEN: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
 
       - name: Commit updated CHANGELOG.md
         run: |
@@ -96,14 +100,13 @@ jobs:
           ./scancode --json-pp ../scancode-result.json ../
 
       - name: Create GitHub Release
-        id: create_release
-        uses: "plu5/automatic-releases-with-sha-action@main"
-        with:
-          repo_token: "${{ secrets.PAT_TOKEN }}"
-          automatic_release_tag: ${{ steps.version.outputs.tag }}
-          prerelease: false
-          title: ASAM OSI Converter ${{ steps.version.outputs.tag }}
-          files: |
-            CHANGELOG.md
-            scancode-result.json
-            lichtblick.asam-osi-converter-${{ steps.version.outputs.version }}.foxe
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "ASAM OSI Converter ${{ steps.version.outputs.tag }}" \
+            --notes-file CHANGELOG.md \
+            --verify-tag \
+            CHANGELOG.md \
+            scancode-result.json \
+            "lichtblick.asam-osi-converter-${{ steps.version.outputs.version }}.foxe"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+# git-cliff configuration for conventional commit changelog generation
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/lichtblick-suite/asam-osi-converter
+{%- endmacro -%}
+
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}]({{ self::remote_url() }}/tree/{{ version }}) — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first | split(pat="\n") | first | trim }}\
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+commit_parsers = [
+  { message = "^feat", group = "🚀 Features" },
+  { message = "^fix", group = "🐛 Bug Fixes" },
+  { message = "^refactor", group = "♻️ Refactoring" },
+  { message = "^docs", group = "📚 Documentation" },
+  { message = "^ci", group = "⚙️ CI/CD" },
+  { message = "^build\\(deps\\)", group = "📦 Dependencies" },
+  { message = "^build", group = "🏗️ Build" },
+  { message = "^chore", group = "🔧 Miscellaneous" },
+  { message = "^test", group = "🧪 Tests" },
+  { message = "^perf", group = "⚡ Performance" },
+  { message = "^style", group = "🎨 Style" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"


### PR DESCRIPTION
## Summary

Fixes release workflow to generate proper conventional commit changelogs.

### Changes
- **Replace `github-changelog-generator`** (Ruby, PR/issue-based) with **`git-cliff`** (conventional commits)
- **Replace `plu5/automatic-releases-with-sha-action`** with **`gh release create --notes-file`** so the release description contains the full changelog
- **Add `cliff.toml`** configuration for conventional commit parsing with grouped categories (Features, Bug Fixes, Refactoring, CI/CD, Dependencies, etc.)

### Problem
The previous setup generated changelogs from merged PRs and closed issues, not from commit messages. Direct pushes to main were invisible in the changelog. The release action also generated its own body, ignoring the CHANGELOG.md content.

### Tested
Same fix was applied and verified on `asam-opendrive-converter` v0.1.0 release.