### PR TITLE
fix(converter): per-panel scene state for toggles and stale entities

### DIFF
--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -12,12 +12,12 @@ The converter uses a multi-layer caching system to avoid redundant work across f
 
 **Purpose:** Skip entire conversion if the same message object arrives again with the same config.
 
-| Property | Value |
-|----------|-------|
-| Structure | `Map<configSignature, WeakMap<GroundTruth, PartialSceneEntity[]>>` |
-| Key | Config signature (outer), message object reference (inner) |
-| Hit condition | Same config + same message object identity |
-| Invalidation | Outer map entry cleared when config signature changes |
+| Property      | Value                                                              |
+| ------------- | ------------------------------------------------------------------ |
+| Structure     | `Map<configSignature, WeakMap<GroundTruth, PartialSceneEntity[]>>` |
+| Key           | Config signature (outer), message object reference (inner)         |
+| Hit condition | Same config + same message object identity                         |
+| Invalidation  | Outer map entry cleared when config signature changes              |
 
 The `WeakMap` allows garbage collection of message objects no longer referenced by the runtime.
 
@@ -25,23 +25,23 @@ The `WeakMap` allows garbage collection of message objects no longer referenced 
 
 **Purpose:** Reuse rendered lane boundary entities when the set of boundaries hasn't changed.
 
-| Property | Value |
-|----------|-------|
-| Structure | `Map<string, PartialSceneEntity[]>` |
-| Key | Hash of all `lane_boundary[].id` values |
-| Hit condition | Same set of boundary IDs (regardless of data changes) |
-| Invalidation | Cleared on config change or when `caching` is disabled |
+| Property      | Value                                                  |
+| ------------- | ------------------------------------------------------ |
+| Structure     | `Map<string, PartialSceneEntity[]>`                    |
+| Key           | Hash of all `lane_boundary[].id` values                |
+| Hit condition | Same set of boundary IDs (regardless of data changes)  |
+| Invalidation  | Cleared on config change or when `caching` is disabled |
 
 ### Lane cache
 
 **Purpose:** Reuse rendered lane entities when both lanes and their referenced boundaries are unchanged.
 
-| Property | Value |
-|----------|-------|
-| Structure | `Map<string, PartialSceneEntity[]>` |
-| Key | Hash of all `lane[].id` values |
-| Hit condition | Boundary cache was hit **and** same set of lane IDs |
-| Invalidation | Cleared on config change; depends on boundary cache state |
+| Property      | Value                                                     |
+| ------------- | --------------------------------------------------------- |
+| Structure     | `Map<string, PartialSceneEntity[]>`                       |
+| Key           | Hash of all `lane[].id` values                            |
+| Hit condition | Boundary cache was hit **and** same set of lane IDs       |
+| Invalidation  | Cleared on config change; depends on boundary cache state |
 
 :::note[Cache dependency]
 
@@ -57,12 +57,12 @@ Same pattern as physical lane caches, for `LogicalLaneBoundary` and `LogicalLane
 
 **Purpose:** Reuse loaded 3D model primitives across frames.
 
-| Property | Value |
-|----------|-------|
-| Structure | `Map<string, ModelPrimitive>` |
-| Key | `defaultModelPath + model_reference` (full file path) |
-| Hit condition | Same model path |
-| Invalidation | Cleared on config change |
+| Property      | Value                                                 |
+| ------------- | ----------------------------------------------------- |
+| Structure     | `Map<string, ModelPrimitive>`                         |
+| Key           | `defaultModelPath + model_reference` (full file path) |
+| Hit condition | Same model path                                       |
+| Invalidation  | Cleared on config change                              |
 
 ## Invalidation triggers
 
@@ -96,3 +96,32 @@ New frame arrives
 - **Static scene** (boundary/lane cache hits): Only moving objects, signs, and lights are rebuilt
 - **Config change**: Full rebuild of all entities (unavoidable)
 - **Typical frame**: Moving objects rebuilt (they change position), geometry reused from cache
+
+## Multi-panel behavior
+
+A single converter instance (one `GroundTruthContext`) is shared by **every panel** that subscribes to the topic. The 3D panel and the Image (camera) panel are separate `PanelExtensionAdapter` instances; each one invokes the converter **independently, once per render tick**, passing its own `event.topicConfig`. Lichtblick does not deduplicate conversion across panels, and the message pipeline hands each subscriber its own array of **shared message references** — so both panels call the converter with the **same `GroundTruth` object**.
+
+### Why the frame cache is keyed by config, not just the message
+
+The cached value is the rendered `SceneUpdate`, which is a function of **(message, config)** — not the message alone. The same `GroundTruth` yields different entities depending on the panel's settings:
+
+- `showPhysicalLanes` / `showLogicalLanes` / `showReferenceLines` — whether those categories appear at all
+- `showBoundingBox` vs `show3dModels` — cubes vs glTF models for objects
+- `showAxes` — whether axis arrows are added
+- `defaultModelPath` — the model URLs
+
+So two panels with **different** settings legitimately need **different** results from the same message and cannot share a cached `SceneUpdate`. Two panels with the **same** settings share a `configSignature` and therefore reuse the frame cache **across panels** (the second panel gets a cache hit).
+
+Even across _different_ configs, the expensive per-feature geometry is still shared: lane/boundary/model entities are keyed by **data content** (entity IDs / model path), so whichever panel converts first builds them and the other reuses them. Only the cheap final assembly (which categories to concatenate, per-object cube primitives) is redone per config. Because the config signature is tracked **per consumer** (see below), two panels with different settings no longer thrash the shared caches.
+
+### Why deletions are tracked per consumer
+
+`SceneEntityDeletion`s are a **per-scene delta** — "what to remove from _this panel's_ accumulated scene since _its_ last frame" — not a per-timestamp value. Each panel keeps its own scene, and the same timestamp can require different deletions per panel (e.g. one panel just toggled a category off and must delete it; the other did not). The `previous*Ids` sets therefore live in a per-consumer `GroundTruthState`, stored in `ctx.consumerStates` keyed by the panel's `topicConfig` object identity (falling back to `DEFAULT_CONFIG`).
+
+A single shared set is **incorrect**, not merely slower: panel invocation order is non-deterministic, so whichever panel converts first would consume the deletion and leave the others showing a stale entity. This previously caused a moving object that left the data to disappear in one panel while remaining in the other.
+
+:::note[Why we can't "compute once per timestamp"]
+
+Lichtblick invokes message converters **per subscribing panel**, not once per message. We cannot change that from inside an extension. What we _can_ do — and do — is make the heavy work message-keyed (geometry caches shared across panels) while keeping the genuinely panel-specific work (config-gated assembly and per-scene deletions) cheap and isolated.
+
+:::

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -120,6 +120,8 @@ Even across _different_ configs, the expensive per-feature geometry is still sha
 
 A single shared set is **incorrect**, not merely slower: panel invocation order is non-deterministic, so whichever panel converts first would consume the deletion and leave the others showing a stale entity. This previously caused a moving object that left the data to disappear in one panel while remaining in the other.
 
+Two panels that are both at **default settings** are a special case: each has `topicConfig === undefined`, so both fall back to the shared `DEFAULT_CONFIG` key and therefore share one state. To keep deletions correct there, the deletion computation is **idempotent per message object** — both panels receive the same `GroundTruth` object, so only the first call diffs the previous-frame id sets; the others reuse the cached result (`state.previousDeletionMessage` / `previousDeletionResult`) instead of re-diffing.
+
 :::note[Why we can't "compute once per timestamp"]
 
 Lichtblick invokes message converters **per subscribing panel**, not once per message. We cannot change that from inside an extension. What we _can_ do — and do — is make the heavy work message-keyed (geometry caches shared across panels) while keeping the genuinely panel-specific work (config-gated assembly and per-scene deletions) cheap and isolated.

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -126,4 +126,6 @@ Two panels that are both at **default settings** are a special case: each has `t
 
 Lichtblick invokes message converters **per subscribing panel**, not once per message. We cannot change that from inside an extension. What we _can_ do — and do — is make the heavy work message-keyed (geometry caches shared across panels) while keeping the genuinely panel-specific work (config-gated assembly and per-scene deletions) cheap and isolated.
 
+This per-consumer, data-driven deletion tracking is a workaround for a framework limitation — SceneUpdate converters are forced to be stateful to emit deletions. Tracked upstream in [lichtblick-suite/lichtblick#1195](https://github.com/lichtblick-suite/lichtblick/issues/1195); it can be simplified once the framework supports self-contained scene updates.
+
 :::

--- a/docs/architecture/converter-pipeline.md
+++ b/docs/architecture/converter-pipeline.md
@@ -12,7 +12,7 @@ This page describes the end-to-end conversion flow for `osi3.GroundTruth → fox
 
 The converter reads panel settings from `event.topicConfig` (typed as `GroundTruthPanelSettings`). If no config is provided, it falls back to `DEFAULT_CONFIG`.
 
-A **config signature** (JSON-stringified config) is computed. If the signature differs from the previous frame, all caches are invalidated.
+A **config signature** (JSON-stringified config) is computed. If the signature differs from the previous frame, all caches are invalidated. The signature and the deletion-tracking state are held **per consumer** (per subscribing panel) — see [Multi-panel behavior](caching.md#multi-panel-behavior).
 
 ### 2. Host vehicle resolution
 
@@ -28,24 +28,24 @@ If caching is enabled, the converter checks a `WeakMap<GroundTruth, entities>` k
 
 ### 4. Deletion detection
 
-For each entity type, the converter compares current-frame entity IDs against a stored `Set<number>` from the previous frame. Missing IDs generate `SceneEntityDeletion` entries with the current timestamp.
+For each entity type, the converter compares current-frame entity IDs against a stored `Set<number>` from the previous frame. Missing IDs generate `SceneEntityDeletion` entries with the current timestamp. These sets are held **per consumer** (`ctx.consumerStates`), so each panel tracks its own scene — see [Multi-panel behavior](caching.md#multi-panel-behavior). Toggleable categories (lanes, logical lanes, reference lines) additionally emit deletions for the current data IDs while hidden, so turning a category off clears it regardless of previous-frame tracking.
 
 ### 5. Entity building
 
 Entities are built by feature modules in this order:
 
-| Step | Feature | Condition | Builder |
-|------|---------|-----------|---------|
-| 1 | Moving objects | Always | `buildMovingObjectEntity()` |
-| 2 | Stationary objects | Always | `buildStationaryObjectEntity()` |
-| 3 | Traffic signs | Always | `buildTrafficSignEntity()` |
-| 4 | Traffic lights | Always | `buildTrafficLightEntity()` |
-| 5 | Road markings | Always (STOP only) | `buildRoadMarkingEntity()` |
-| 6 | Lane boundaries | `showPhysicalLanes` | `buildLaneBoundaryEntity()` |
-| 7 | Lanes | `showPhysicalLanes` | `buildLaneEntity()` |
-| 8 | Logical lane boundaries | `showLogicalLanes` | `buildLogicalLaneBoundaryEntity()` |
-| 9 | Logical lanes | `showLogicalLanes` | `buildLogicalLaneEntity()` |
-| 10 | Reference lines | `showReferenceLines` | `buildReferenceLineEntity()` |
+| Step | Feature                 | Condition            | Builder                            |
+| ---- | ----------------------- | -------------------- | ---------------------------------- |
+| 1    | Moving objects          | Always               | `buildMovingObjectEntity()`        |
+| 2    | Stationary objects      | Always               | `buildStationaryObjectEntity()`    |
+| 3    | Traffic signs           | Always               | `buildTrafficSignEntity()`         |
+| 4    | Traffic lights          | Always               | `buildTrafficLightEntity()`        |
+| 5    | Road markings           | Always (STOP only)   | `buildRoadMarkingEntity()`         |
+| 6    | Lane boundaries         | `showPhysicalLanes`  | `buildLaneBoundaryEntity()`        |
+| 7    | Lanes                   | `showPhysicalLanes`  | `buildLaneEntity()`                |
+| 8    | Logical lane boundaries | `showLogicalLanes`   | `buildLogicalLaneBoundaryEntity()` |
+| 9    | Logical lanes           | `showLogicalLanes`   | `buildLogicalLaneEntity()`         |
+| 10   | Reference lines         | `showReferenceLines` | `buildReferenceLineEntity()`       |
 
 ### 6. Geometry cache reuse
 
@@ -64,7 +64,7 @@ See [Caching](caching.md) for details.
 
 After building entities:
 
-- Update `previousXyzIds` sets for next frame's deletion detection
+- Update the per-consumer `previousXyzIds` sets for next frame's deletion detection
 - Store current config and config signature
 - Populate frame cache and geometry caches
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Visualises data following the standard of the ASAM Open Simulation Interface (ASAM OSI) using the native 3D panel of Lichtblick",
   "publisher": "Lichtblick",
   "homepage": "https://www.asam.net/standards/detail/osi/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "./dist/extension.js",
   "keywords": [

--- a/src/converters/groundTruth/context.ts
+++ b/src/converters/groundTruth/context.ts
@@ -14,6 +14,8 @@ export function createGroundTruthState(): GroundTruthState {
     previousReferenceLineIds: new Set(),
     previousConfig: undefined,
     previousConfigSignature: undefined,
+    previousDeletionMessage: undefined,
+    previousDeletionResult: undefined,
   };
 }
 

--- a/src/converters/groundTruth/context.ts
+++ b/src/converters/groundTruth/context.ts
@@ -1,4 +1,21 @@
-import { GroundTruthContext } from "./types";
+import { GroundTruthContext, GroundTruthState } from "./types";
+
+export function createGroundTruthState(): GroundTruthState {
+  return {
+    previousMovingObjectIds: new Set(),
+    previousStationaryObjectIds: new Set(),
+    previousLaneBoundaryIds: new Set(),
+    previousLogicalLaneBoundaryIds: new Set(),
+    previousLaneIds: new Set(),
+    previousLogicalLaneIds: new Set(),
+    previousTrafficSignIds: new Set(),
+    previousTrafficLightIds: new Set(),
+    previousRoadMarkingIds: new Set(),
+    previousReferenceLineIds: new Set(),
+    previousConfig: undefined,
+    previousConfigSignature: undefined,
+  };
+}
 
 export function createGroundTruthContext(): GroundTruthContext {
   return {
@@ -8,19 +25,21 @@ export function createGroundTruthContext(): GroundTruthContext {
     logicalLaneBoundaryCache: new Map(),
     logicalLaneCache: new Map(),
     modelCache: new Map(),
-    state: {
-      previousMovingObjectIds: new Set(),
-      previousStationaryObjectIds: new Set(),
-      previousLaneBoundaryIds: new Set(),
-      previousLogicalLaneBoundaryIds: new Set(),
-      previousLaneIds: new Set(),
-      previousLogicalLaneIds: new Set(),
-      previousTrafficSignIds: new Set(),
-      previousTrafficLightIds: new Set(),
-      previousRoadMarkingIds: new Set(),
-      previousReferenceLineIds: new Set(),
-      previousConfig: undefined,
-      previousConfigSignature: undefined,
-    },
+    consumerStates: new WeakMap(),
   };
+}
+
+/**
+ * Returns the deletion-tracking state for a single consumer (panel), creating it
+ * on first use. `configKey` is the panel's `topicConfig` object (or the shared
+ * `DEFAULT_CONFIG`), which is stable per panel for as long as its settings are
+ * unchanged, so it uniquely identifies a consumer of the shared context.
+ */
+export function getConsumerState(ctx: GroundTruthContext, configKey: object): GroundTruthState {
+  let consumerState = ctx.consumerStates.get(configKey);
+  if (!consumerState) {
+    consumerState = createGroundTruthState();
+    ctx.consumerStates.set(configKey, consumerState);
+  }
+  return consumerState;
 }

--- a/src/converters/groundTruth/sceneUpdateConverter.ts
+++ b/src/converters/groundTruth/sceneUpdateConverter.ts
@@ -24,10 +24,10 @@ import {
   createRenderedPhysicalLaneCacheKey,
 } from "@utils/cacheKeys";
 import { convertPathToFileUrl, osiTimestampToTime } from "@utils/helper";
-import { getDeletedEntities, PartialSceneEntity } from "@utils/scene";
+import { getCategoryDeletions, getDeletedEntities, PartialSceneEntity } from "@utils/scene";
 import { DeepPartial, DeepRequired } from "ts-essentials";
 
-import { createGroundTruthContext } from "./context";
+import { createGroundTruthContext, getConsumerState } from "./context";
 import { DEFAULT_CONFIG } from "./panelSettings";
 import {
   GroundTruthPanelSettings,
@@ -257,14 +257,8 @@ export function convertGroundTruthToSceneUpdate(
   hostVehicleIdFallback?: number,
   emitAlert?: MessageConverterEmitAlert,
 ): DeepPartial<SceneUpdate> {
-  const {
-    laneBoundaryCache,
-    laneCache,
-    logicalLaneBoundaryCache,
-    logicalLaneCache,
-    modelCache,
-    state,
-  } = ctx;
+  const { laneBoundaryCache, laneCache, logicalLaneBoundaryCache, logicalLaneCache, modelCache } =
+    ctx;
 
   const osiGroundTruthReq = osiGroundTruth as DeepRequired<GroundTruth>;
   const timestamp = osiTimestampToTime(osiGroundTruthReq.timestamp);
@@ -300,6 +294,16 @@ export function convertGroundTruthToSceneUpdate(
   }
 
   const config = (event?.topicConfig as GroundTruthPanelSettings | undefined) ?? DEFAULT_CONFIG;
+
+  // Deletion tracking (previous-frame entity ids + config signature) must be
+  // isolated per consumer. A single converter instance is shared across every
+  // panel subscribed to this schema (e.g. the 3D and Image panels both consume
+  // SensorView), but each panel renders into its own scene. `config` is the
+  // panel's stable `topicConfig` object (or the shared `DEFAULT_CONFIG`), so it
+  // is a safe per-consumer key. Sharing one state lets the first panel to
+  // convert consume a deletion, leaving the others showing a stale entity.
+  const state = getConsumerState(ctx, config);
+
   // Cache signature ties caches to settings so data is not reused across different panel settings
   const configSignature = JSON.stringify({
     caching: config.caching,
@@ -358,35 +362,36 @@ export function convertGroundTruthToSceneUpdate(
       PREFIX_ROAD_MARKING,
       timestamp,
     ),
-    ...getDeletedEntities(
-      config.showPhysicalLanes ? osiGroundTruthReq.lane_boundary : [],
+    ...getCategoryDeletions(
+      osiGroundTruthReq.lane_boundary,
       state.previousLaneBoundaryIds,
       PREFIX_LANE_BOUNDARY,
       timestamp,
+      { visible: config.showPhysicalLanes },
     ),
-    ...getDeletedEntities(
-      config.showLogicalLanes ? osiGroundTruthReq.logical_lane_boundary : [],
+    ...getCategoryDeletions(
+      osiGroundTruthReq.logical_lane_boundary,
       state.previousLogicalLaneBoundaryIds,
       PREFIX_LOGICAL_LANE_BOUNDARY,
       timestamp,
+      { visible: config.showLogicalLanes },
     ),
-    ...getDeletedEntities(
-      config.showPhysicalLanes ? osiGroundTruthReq.lane : [],
-      state.previousLaneIds,
-      PREFIX_LANE,
-      timestamp,
-    ),
-    ...getDeletedEntities(
-      config.showLogicalLanes ? osiGroundTruthReq.logical_lane : [],
+    ...getCategoryDeletions(osiGroundTruthReq.lane, state.previousLaneIds, PREFIX_LANE, timestamp, {
+      visible: config.showPhysicalLanes,
+    }),
+    ...getCategoryDeletions(
+      osiGroundTruthReq.logical_lane,
       state.previousLogicalLaneIds,
       PREFIX_LOGICAL_LANE,
       timestamp,
+      { visible: config.showLogicalLanes },
     ),
-    ...getDeletedEntities(
-      config.showReferenceLines ? osiGroundTruthReq.reference_line : [],
+    ...getCategoryDeletions(
+      osiGroundTruthReq.reference_line,
       state.previousReferenceLineIds,
       PREFIX_REFERENCE_LINE,
       timestamp,
+      { visible: config.showReferenceLines },
     ),
   ];
 

--- a/src/converters/groundTruth/sceneUpdateConverter.ts
+++ b/src/converters/groundTruth/sceneUpdateConverter.ts
@@ -332,6 +332,13 @@ export function convertGroundTruthToSceneUpdate(
 
   // Deletions logic (comparing previous step's entities with current step's entities).
   //
+  // TODO(lichtblick-suite/lichtblick#1195): This per-consumer, data-driven
+  // deletion tracking is a workaround. SceneUpdate converters are forced to be
+  // stateful (and per-consumer) to emit deletions when entities leave the data,
+  // which is really protocol/visualization-state concern rather than pure
+  // transformation. Remove once the framework supports self-contained scene
+  // updates / framework-managed entity lifecycle.
+  //
   // Computed once per message object per consumer state: when several panels
   // share one state (e.g. two panels both at default settings, both resolving to
   // `DEFAULT_CONFIG`), Lichtblick hands them the same message object. Only the

--- a/src/converters/groundTruth/sceneUpdateConverter.ts
+++ b/src/converters/groundTruth/sceneUpdateConverter.ts
@@ -330,70 +330,92 @@ export function convertGroundTruthToSceneUpdate(
   state.previousConfigSignature = configSignature;
   const caching = config.caching;
 
-  // Deletions logic (comparing previous step's entities with current step's entities)
-  const deletions = [
-    ...getDeletedEntities(
-      osiGroundTruthReq.moving_object,
-      state.previousMovingObjectIds,
-      PREFIX_MOVING_OBJECT,
-      timestamp,
-    ),
-    ...getDeletedEntities(
-      osiGroundTruthReq.stationary_object,
-      state.previousStationaryObjectIds,
-      PREFIX_STATIONARY_OBJECT,
-      timestamp,
-    ),
-    ...getDeletedEntities(
-      osiGroundTruthReq.traffic_sign,
-      state.previousTrafficSignIds,
-      PREFIX_TRAFFIC_SIGN,
-      timestamp,
-    ),
-    ...getDeletedEntities(
-      osiGroundTruthReq.traffic_light,
-      state.previousTrafficLightIds,
-      PREFIX_TRAFFIC_LIGHT,
-      timestamp,
-    ),
-    ...getDeletedEntities(
-      osiGroundTruthReq.road_marking,
-      state.previousRoadMarkingIds,
-      PREFIX_ROAD_MARKING,
-      timestamp,
-    ),
-    ...getCategoryDeletions(
-      osiGroundTruthReq.lane_boundary,
-      state.previousLaneBoundaryIds,
-      PREFIX_LANE_BOUNDARY,
-      timestamp,
-      { visible: config.showPhysicalLanes },
-    ),
-    ...getCategoryDeletions(
-      osiGroundTruthReq.logical_lane_boundary,
-      state.previousLogicalLaneBoundaryIds,
-      PREFIX_LOGICAL_LANE_BOUNDARY,
-      timestamp,
-      { visible: config.showLogicalLanes },
-    ),
-    ...getCategoryDeletions(osiGroundTruthReq.lane, state.previousLaneIds, PREFIX_LANE, timestamp, {
-      visible: config.showPhysicalLanes,
-    }),
-    ...getCategoryDeletions(
-      osiGroundTruthReq.logical_lane,
-      state.previousLogicalLaneIds,
-      PREFIX_LOGICAL_LANE,
-      timestamp,
-      { visible: config.showLogicalLanes },
-    ),
-    ...getCategoryDeletions(
-      osiGroundTruthReq.reference_line,
-      state.previousReferenceLineIds,
-      PREFIX_REFERENCE_LINE,
-      timestamp,
-      { visible: config.showReferenceLines },
-    ),
-  ];
+  // Deletions logic (comparing previous step's entities with current step's entities).
+  //
+  // Computed once per message object per consumer state: when several panels
+  // share one state (e.g. two panels both at default settings, both resolving to
+  // `DEFAULT_CONFIG`), Lichtblick hands them the same message object. Only the
+  // first call diffs the previous-frame id sets; the others reuse the result, so
+  // a departed entity is deleted in every panel instead of only the first.
+  let deletions: PartialSceneEntity[];
+  if (
+    state.previousDeletionMessage === osiGroundTruth &&
+    state.previousDeletionResult != undefined
+  ) {
+    deletions = state.previousDeletionResult;
+  } else {
+    deletions = [
+      ...getDeletedEntities(
+        osiGroundTruthReq.moving_object,
+        state.previousMovingObjectIds,
+        PREFIX_MOVING_OBJECT,
+        timestamp,
+      ),
+      ...getDeletedEntities(
+        osiGroundTruthReq.stationary_object,
+        state.previousStationaryObjectIds,
+        PREFIX_STATIONARY_OBJECT,
+        timestamp,
+      ),
+      ...getDeletedEntities(
+        osiGroundTruthReq.traffic_sign,
+        state.previousTrafficSignIds,
+        PREFIX_TRAFFIC_SIGN,
+        timestamp,
+      ),
+      ...getDeletedEntities(
+        osiGroundTruthReq.traffic_light,
+        state.previousTrafficLightIds,
+        PREFIX_TRAFFIC_LIGHT,
+        timestamp,
+      ),
+      ...getDeletedEntities(
+        osiGroundTruthReq.road_marking,
+        state.previousRoadMarkingIds,
+        PREFIX_ROAD_MARKING,
+        timestamp,
+      ),
+      ...getCategoryDeletions(
+        osiGroundTruthReq.lane_boundary,
+        state.previousLaneBoundaryIds,
+        PREFIX_LANE_BOUNDARY,
+        timestamp,
+        { visible: config.showPhysicalLanes },
+      ),
+      ...getCategoryDeletions(
+        osiGroundTruthReq.logical_lane_boundary,
+        state.previousLogicalLaneBoundaryIds,
+        PREFIX_LOGICAL_LANE_BOUNDARY,
+        timestamp,
+        { visible: config.showLogicalLanes },
+      ),
+      ...getCategoryDeletions(
+        osiGroundTruthReq.lane,
+        state.previousLaneIds,
+        PREFIX_LANE,
+        timestamp,
+        {
+          visible: config.showPhysicalLanes,
+        },
+      ),
+      ...getCategoryDeletions(
+        osiGroundTruthReq.logical_lane,
+        state.previousLogicalLaneIds,
+        PREFIX_LOGICAL_LANE,
+        timestamp,
+        { visible: config.showLogicalLanes },
+      ),
+      ...getCategoryDeletions(
+        osiGroundTruthReq.reference_line,
+        state.previousReferenceLineIds,
+        PREFIX_REFERENCE_LINE,
+        timestamp,
+        { visible: config.showReferenceLines },
+      ),
+    ];
+    state.previousDeletionMessage = osiGroundTruth;
+    state.previousDeletionResult = deletions;
+  }
 
   // Frame cache is partitioned by config signature to prevent cross-config reuse.
   // Respect `caching=false` by skipping frame-level cache reads/writes entirely.

--- a/src/converters/groundTruth/types.ts
+++ b/src/converters/groundTruth/types.ts
@@ -55,5 +55,17 @@ export interface GroundTruthContext {
   logicalLaneBoundaryCache: Map<string, PartialSceneEntity[]>;
   logicalLaneCache: Map<string, PartialSceneEntity[]>;
   modelCache: Map<string, ModelPrimitive>;
-  state: GroundTruthState;
+  /**
+   * Per-consumer deletion-tracking state, keyed by the panel's `topicConfig`
+   * object (or `DEFAULT_CONFIG` when a panel has no topic config yet).
+   *
+   * A single converter instance is shared across every panel that subscribes to
+   * the same schema — e.g. the 3D panel and the Image panel both consuming
+   * SensorView. Each panel renders into its own scene, so the previous-frame
+   * entity-id sets used to compute MATCHING_ID deletions must be tracked per
+   * consumer. With a single shared set, the panel that converts first consumes a
+   * deletion and the others see no change, leaving a stale entity (e.g. a moving
+   * object that left the data still shown in one panel).
+   */
+  consumerStates: WeakMap<object, GroundTruthState>;
 }

--- a/src/converters/groundTruth/types.ts
+++ b/src/converters/groundTruth/types.ts
@@ -46,6 +46,17 @@ export interface GroundTruthState {
   previousReferenceLineIds: Set<number>;
   previousConfig?: GroundTruthPanelSettings;
   previousConfigSignature?: string;
+  /**
+   * The last GroundTruth message for which deletions were computed, and the
+   * resulting deletions. Used to make deletion computation idempotent per
+   * message: when several panels share one state (e.g. two panels both at
+   * default settings, which both resolve to `DEFAULT_CONFIG`), they all receive
+   * the same message object, so only the first should diff the previous-frame id
+   * sets. The others reuse the result instead of re-diffing (which would mutate
+   * the id sets again and drop the deletions).
+   */
+  previousDeletionMessage?: GroundTruth;
+  previousDeletionResult?: PartialSceneEntity[];
 }
 
 export interface GroundTruthContext {

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -60,3 +60,47 @@ export function getDeletedEntities<T extends { id: { value: number } }>(
     type: SceneEntityDeletionType.MATCHING_ID,
   }));
 }
+
+/**
+ * Computes deletions for an entity category whose visibility can be toggled via
+ * panel settings (e.g. physical/logical lanes, reference lines).
+ *
+ * - When the category is `visible`, this behaves exactly like
+ *   {@link getDeletedEntities}: it deletes entities that were present in the
+ *   previous frame but are absent from the current data, and records the
+ *   current ids for the next comparison.
+ * - When the category is hidden, it deletes every id currently present in the
+ *   data (plus any id still tracked from a previous frame) and clears the
+ *   tracking set. Deleting the current data ids on every hidden frame makes
+ *   turning a category off reliably remove its entities even when a single
+ *   converter context is shared across multiple panels (e.g. the 3D and Image
+ *   panels both consuming SensorView). In that case the previous-frame id sets
+ *   are clobbered between panels, so relying on them alone can drop the
+ *   deletions and leave hidden entities stuck on screen.
+ *
+ * @param osiEntities - The array of entities from the current frame.
+ * @param previousFrameIds - The set of ids tracked from the previous frame.
+ * @param entityPrefix - The prefix used to build scene entity ids.
+ * @param timestamp - The timestamp to associate with the deletions.
+ * @param options.visible - Whether the category is currently shown.
+ */
+export function getCategoryDeletions<T extends { id: { value: number } }>(
+  osiEntities: DeepRequired<T[]>,
+  previousFrameIds: Set<number>,
+  entityPrefix: string,
+  timestamp: Time,
+  { visible }: { visible: boolean },
+): PartialSceneEntity[] {
+  if (visible) {
+    return getDeletedEntities(osiEntities, previousFrameIds, entityPrefix, timestamp);
+  }
+
+  const idsToDelete = new Set<number>(previousFrameIds);
+  osiEntities.forEach((entity) => idsToDelete.add(entity.id.value));
+  previousFrameIds.clear();
+  return Array.from(idsToDelete).map((id) => ({
+    id: generateSceneEntityId(entityPrefix, id),
+    timestamp,
+    type: SceneEntityDeletionType.MATCHING_ID,
+  }));
+}

--- a/tests/multiPanelDeletion.spec.ts
+++ b/tests/multiPanelDeletion.spec.ts
@@ -6,6 +6,10 @@ import { DeepRequired } from "ts-essentials";
 jest.mock("@features/trafficlights", () => ({ buildTrafficLightEntity: jest.fn(() => undefined) }));
 jest.mock("@features/trafficsigns", () => ({ buildTrafficSignEntity: jest.fn(() => undefined) }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 function movingObject(id: number, x: number) {
   return {
     id: { value: id },

--- a/tests/multiPanelDeletion.spec.ts
+++ b/tests/multiPanelDeletion.spec.ts
@@ -1,0 +1,101 @@
+import { convertGroundTruthToSceneUpdate, createGroundTruthContext } from "@converters";
+import { SceneEntityDeletionType } from "@foxglove/schemas";
+import { MovingObject_Type, type GroundTruth } from "@lichtblick/asam-osi-types";
+import { DeepRequired } from "ts-essentials";
+
+jest.mock("@features/trafficlights", () => ({ buildTrafficLightEntity: jest.fn(() => undefined) }));
+jest.mock("@features/trafficsigns", () => ({ buildTrafficSignEntity: jest.fn(() => undefined) }));
+
+function movingObject(id: number, x: number) {
+  return {
+    id: { value: id },
+    type: MovingObject_Type.VEHICLE,
+    model_reference: "",
+    base: {
+      position: { x, y: 0, z: 0 },
+      orientation: { roll: 0, pitch: 0, yaw: 0 },
+      dimension: { width: 2, length: 4, height: 1.5 },
+      velocity: { x: 0, y: 0, z: 0 },
+      acceleration: { x: 0, y: 0, z: 0 },
+    },
+  };
+}
+
+function groundTruth(movingObjectIds: Array<{ id: number; x: number }>): GroundTruth {
+  return {
+    timestamp: { seconds: 1, nanos: 0 },
+    host_vehicle_id: { value: 0 },
+    moving_object: movingObjectIds.map(({ id, x }) => movingObject(id, x)),
+    stationary_object: [],
+    traffic_sign: [],
+    traffic_light: [],
+    road_marking: [],
+    reference_line: [],
+    lane_boundary: [],
+    lane: [],
+    logical_lane_boundary: [],
+    logical_lane: [],
+  } as unknown as DeepRequired<GroundTruth>;
+}
+
+const baseConfig = {
+  caching: true,
+  showAxes: false,
+  showPhysicalLanes: false,
+  showLogicalLanes: false,
+  showReferenceLines: false,
+  showBoundingBox: true,
+  show3dModels: false,
+  defaultModelPath: "",
+};
+
+class PanelScene {
+  public ids = new Set<string>();
+  public apply(update: { deletions?: unknown[]; entities?: unknown[] }): void {
+    for (const deletion of update.deletions ?? []) {
+      const del = deletion as { id: string; type: SceneEntityDeletionType };
+      if (del.type === SceneEntityDeletionType.MATCHING_ID) {
+        this.ids.delete(del.id);
+      }
+    }
+    for (const entity of update.entities ?? []) {
+      this.ids.add((entity as { id: string }).id);
+    }
+  }
+  public has(id: string): boolean {
+    return this.ids.has(id);
+  }
+}
+
+describe("multi-panel moving-object deletion (shared converter context)", () => {
+  it("removes a departed object from BOTH panels that share one context", () => {
+    // The 3D and Image panels both subscribe to SensorView and therefore share a
+    // single converter context, but each keeps its own scene and panel config.
+    const ctx = createGroundTruthContext();
+    const event3D = { topicConfig: { ...baseConfig } } as never;
+    const eventImage = { topicConfig: { ...baseConfig } } as never;
+
+    const scene3D = new PanelScene();
+    const sceneImage = new PanelScene();
+
+    // Frame 1: host (0) and lead vehicle (1384) both present.
+    const frame1 = groundTruth([
+      { id: 0, x: 0 },
+      { id: 1384, x: 50 },
+    ]);
+    scene3D.apply(convertGroundTruthToSceneUpdate(ctx, frame1, event3D));
+    sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, frame1, eventImage));
+
+    expect(scene3D.has("moving_object_1384")).toBe(true);
+    expect(sceneImage.has("moving_object_1384")).toBe(true);
+
+    // Frame 2: lead vehicle leaves the (filtered) data; only host remains.
+    const frame2 = groundTruth([{ id: 0, x: 0 }]);
+    scene3D.apply(convertGroundTruthToSceneUpdate(ctx, frame2, event3D));
+    sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, frame2, eventImage));
+
+    // Both panels must drop the departed object — no stale box in either.
+    expect(scene3D.has("moving_object_1384")).toBe(false);
+    expect(sceneImage.has("moving_object_1384")).toBe(false);
+  });
+});

--- a/tests/multiPanelDeletion.spec.ts
+++ b/tests/multiPanelDeletion.spec.ts
@@ -98,4 +98,30 @@ describe("multi-panel moving-object deletion (shared converter context)", () => 
     expect(scene3D.has("moving_object_1384")).toBe(false);
     expect(sceneImage.has("moving_object_1384")).toBe(false);
   });
+
+  it("removes a departed object from BOTH panels when both are at default settings", () => {
+    // Two unconfigured panels both have `topicConfig === undefined`, so both fall
+    // back to the shared `DEFAULT_CONFIG` key and share one consumer state. In
+    // Lichtblick both panels receive the *same* message object, which the
+    // converter relies on to compute deletions once and reuse them.
+    const ctx = createGroundTruthContext();
+    const scene3D = new PanelScene();
+    const sceneImage = new PanelScene();
+    const defaultEvent = () => ({ topicConfig: undefined }) as never;
+
+    const frame1 = groundTruth([
+      { id: 0, x: 0 },
+      { id: 1384, x: 50 },
+    ]);
+    scene3D.apply(convertGroundTruthToSceneUpdate(ctx, frame1, defaultEvent()));
+    sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, frame1, defaultEvent()));
+    expect(scene3D.has("moving_object_1384")).toBe(true);
+    expect(sceneImage.has("moving_object_1384")).toBe(true);
+
+    const frame2 = groundTruth([{ id: 0, x: 0 }]);
+    scene3D.apply(convertGroundTruthToSceneUpdate(ctx, frame2, defaultEvent()));
+    sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, frame2, defaultEvent()));
+    expect(scene3D.has("moving_object_1384")).toBe(false);
+    expect(sceneImage.has("moving_object_1384")).toBe(false);
+  });
 });

--- a/tests/visibilityToggle.spec.ts
+++ b/tests/visibilityToggle.spec.ts
@@ -1,0 +1,219 @@
+import { convertGroundTruthToSceneUpdate, createGroundTruthContext } from "@converters";
+import { SceneEntityDeletionType } from "@foxglove/schemas";
+import { type GroundTruth } from "@lichtblick/asam-osi-types";
+import { getCategoryDeletions, getDeletedEntities, PartialSceneEntity } from "@utils/scene";
+import { DeepRequired } from "ts-essentials";
+
+import { PREFIX_LOGICAL_LANE } from "@/config/entityPrefixes";
+
+jest.mock("@features/trafficlights", () => ({
+  buildTrafficLightEntity: jest.fn(() => undefined),
+}));
+
+jest.mock("@features/trafficsigns", () => ({
+  buildTrafficSignEntity: jest.fn(() => undefined),
+}));
+
+const TIME = { sec: 1, nsec: 0 };
+
+type IdEntity = { id: { value: number } };
+
+function entities(ids: number[]): DeepRequired<IdEntity[]> {
+  return ids.map((value) => ({ id: { value } })) as unknown as DeepRequired<IdEntity[]>;
+}
+
+describe("getCategoryDeletions", () => {
+  it("behaves like getDeletedEntities when the category is visible", () => {
+    const visiblePrev = new Set<number>([1, 2, 3]);
+    const diffPrev = new Set<number>([1, 2, 3]);
+
+    const visible = getCategoryDeletions(entities([2, 3]), visiblePrev, PREFIX_LOGICAL_LANE, TIME, {
+      visible: true,
+    });
+    const diff = getDeletedEntities(entities([2, 3]), diffPrev, PREFIX_LOGICAL_LANE, TIME);
+
+    expect(visible).toEqual(diff);
+    // Only the id missing from the current frame (1) is deleted.
+    expect(visible.map((d) => d.id)).toEqual([`${PREFIX_LOGICAL_LANE}_1`]);
+    // Tracking set now mirrors the current frame for the next comparison.
+    expect([...visiblePrev].sort()).toEqual([2, 3]);
+  });
+
+  it("deletes every current data id when the category is hidden", () => {
+    const previousFrameIds = new Set<number>([10]);
+
+    const deletions = getCategoryDeletions(
+      entities([10, 11, 12]),
+      previousFrameIds,
+      PREFIX_LOGICAL_LANE,
+      TIME,
+      { visible: false },
+    );
+
+    // Deletes the union of previously tracked ids and the current data ids so a
+    // hidden category is reliably cleared regardless of previous-frame tracking.
+    expect(deletions.map((d) => d.id).sort()).toEqual([
+      `${PREFIX_LOGICAL_LANE}_10`,
+      `${PREFIX_LOGICAL_LANE}_11`,
+      `${PREFIX_LOGICAL_LANE}_12`,
+    ]);
+    deletions.forEach((d) => {
+      expect((d as PartialSceneEntity & { type: SceneEntityDeletionType }).type).toBe(
+        SceneEntityDeletionType.MATCHING_ID,
+      );
+    });
+    // Tracking is cleared while hidden.
+    expect(previousFrameIds.size).toBe(0);
+  });
+
+  it("still deletes current data ids when hidden even with no previous tracking", () => {
+    const previousFrameIds = new Set<number>();
+
+    const deletions = getCategoryDeletions(
+      entities([7, 8]),
+      previousFrameIds,
+      PREFIX_LOGICAL_LANE,
+      TIME,
+      { visible: false },
+    );
+
+    expect(deletions.map((d) => d.id).sort()).toEqual([
+      `${PREFIX_LOGICAL_LANE}_7`,
+      `${PREFIX_LOGICAL_LANE}_8`,
+    ]);
+  });
+});
+
+/**
+ * Minimal but complete logical-lane GroundTruth so the real logical-lane entity
+ * and metadata builders run without throwing.
+ */
+function createLogicalLaneGroundTruth(): GroundTruth {
+  const boundaryLine = (y: number) => [
+    { position: { x: 0, y, z: 0 }, s_position: 0, t_position: 0 },
+    { position: { x: 10, y, z: 0 }, s_position: 10, t_position: 0 },
+    { position: { x: 20, y, z: 0 }, s_position: 20, t_position: 0 },
+  ];
+  const boundary = (id: number, y: number) => ({
+    id: { value: id },
+    boundary_line: boundaryLine(y),
+    reference_line_id: { value: 9000 },
+    physical_boundary_id: [],
+    passing_rule: 0,
+  });
+  const lane = (id: number, left: number, right: number) => ({
+    id: { value: id },
+    type: 1,
+    physical_lane_reference: [],
+    reference_line_id: { value: 9000 },
+    start_s: 0,
+    end_s: 20,
+    move_direction: 0,
+    right_adjacent_lane: [],
+    left_adjacent_lane: [],
+    overlapping_lane: [],
+    right_boundary_id: [{ value: right }],
+    left_boundary_id: [{ value: left }],
+    predecessor_lane: [],
+    successor_lane: [],
+    street_name: "",
+  });
+
+  return {
+    timestamp: { seconds: 1, nanos: 0 },
+    host_vehicle_id: { value: 0 },
+    moving_object: [],
+    stationary_object: [],
+    traffic_sign: [],
+    traffic_light: [],
+    road_marking: [],
+    reference_line: [],
+    lane_boundary: [],
+    lane: [],
+    logical_lane_boundary: [boundary(1301, 0), boundary(1302, 3)],
+    logical_lane: [lane(1373, 1302, 1301)],
+  } as unknown as DeepRequired<GroundTruth>;
+}
+
+const baseConfig = {
+  caching: true,
+  showAxes: false,
+  showPhysicalLanes: false,
+  showLogicalLanes: false,
+  showReferenceLines: false,
+  showBoundingBox: true,
+  show3dModels: false,
+  defaultModelPath: "",
+};
+
+/** Models a single panel's accumulated scene from SceneUpdate messages. */
+class PanelScene {
+  public ids = new Set<string>();
+
+  public apply(update: { deletions?: unknown[]; entities?: unknown[] }): void {
+    // Deletions are applied before entities, matching the 3D renderer.
+    for (const deletion of update.deletions ?? []) {
+      const del = deletion as { id: string; type: SceneEntityDeletionType };
+      if (del.type === SceneEntityDeletionType.MATCHING_ID) {
+        this.ids.delete(del.id);
+      }
+    }
+    for (const entity of update.entities ?? []) {
+      this.ids.add((entity as { id: string }).id);
+    }
+  }
+
+  public logicalLaneCount(): number {
+    return [...this.ids].filter((id) => id.startsWith("logical_lane")).length;
+  }
+}
+
+describe("logical lane visibility toggle", () => {
+  it("turning logical lanes off removes them from a single panel", () => {
+    const ctx = createGroundTruthContext();
+    const msg = createLogicalLaneGroundTruth();
+    const scene = new PanelScene();
+
+    scene.apply(
+      convertGroundTruthToSceneUpdate(ctx, msg, {
+        topicConfig: { ...baseConfig, showLogicalLanes: true },
+      } as never),
+    );
+    expect(scene.logicalLaneCount()).toBeGreaterThan(0);
+
+    scene.apply(
+      convertGroundTruthToSceneUpdate(ctx, msg, {
+        topicConfig: { ...baseConfig, showLogicalLanes: false },
+      } as never),
+    );
+    expect(scene.logicalLaneCount()).toBe(0);
+  });
+
+  it("turning logical lanes off in one panel clears them even when a context is shared across panels", () => {
+    // A single converter context is shared by the 3D and Image panels (both
+    // subscribe to SensorView). Each panel keeps its own scene and config.
+    const ctx = createGroundTruthContext();
+    const msg = createLogicalLaneGroundTruth();
+    const scene3D = new PanelScene();
+    const sceneImage = new PanelScene();
+
+    const config3DOn = { topicConfig: { ...baseConfig, showLogicalLanes: true } } as never;
+    const config3DOff = { topicConfig: { ...baseConfig, showLogicalLanes: false } } as never;
+    const configImageOff = { topicConfig: { ...baseConfig, showLogicalLanes: false } } as never;
+
+    // 3D shows logical lanes while the Image panel keeps them hidden.
+    for (let tick = 0; tick < 3; tick++) {
+      scene3D.apply(convertGroundTruthToSceneUpdate(ctx, msg, config3DOn));
+      sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, msg, configImageOff));
+    }
+    expect(scene3D.logicalLaneCount()).toBeGreaterThan(0);
+    expect(sceneImage.logicalLaneCount()).toBe(0);
+
+    // The user toggles logical lanes off in the 3D panel.
+    for (let tick = 0; tick < 3; tick++) {
+      scene3D.apply(convertGroundTruthToSceneUpdate(ctx, msg, config3DOff));
+      sceneImage.apply(convertGroundTruthToSceneUpdate(ctx, msg, configImageOff));
+    }
+    expect(scene3D.logicalLaneCount()).toBe(0);
+  });
+});

--- a/tests/visibilityToggle.spec.ts
+++ b/tests/visibilityToggle.spec.ts
@@ -14,6 +14,10 @@ jest.mock("@features/trafficsigns", () => ({
   buildTrafficSignEntity: jest.fn(() => undefined),
 }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 const TIME = { sec: 1, nsec: 0 };
 
 type IdEntity = { id: { value: number } };


### PR DESCRIPTION
## Summary

The SceneUpdate converter is registered once and shared across every panel that
subscribes to the topic (e.g. the **3D panel** and the **Image panel** both consume
`osi3.SensorView`). Each panel renders into its own scene, but the converter kept a
**single shared deletion-tracking state**. This caused two visible bugs:

1. **Visibility toggles didn't take effect.** Turning *Show Logical Lanes* (or physical
   lanes / reference lines) off in one panel left the already-rendered geometry on screen,
   because the per-frame deletions relied on previous-frame id sets that another panel
   could clear.
2. **Stale bounding boxes across panels.** When a moving object left the (filtered)
   ground-truth data, only the first panel to convert received the `MATCHING_ID` deletion;
   the others kept a stale box. This is why a vehicle could be gone in the 3D panel but
   still shown in the Image panel (observed at t≈5.445 s, where the lead vehicle leaves the
   data).

## Fix

- Track deletion state **per consumer**, keyed by the panel's `topicConfig` object identity
  (stable per panel while its settings are unchanged), so each panel computes its own entity
  deletions.
- For toggleable categories, emit deletions for the **current data ids whenever the category
  is hidden**, so turning a category off reliably clears it regardless of shared state.
- Geometry/model/frame caches remain shared and content/signature-keyed.

## Testing

- `yarn test` — 14 suites / 74 tests pass, including:
  - `tests/visibilityToggle.spec.ts` — logical-lane on/off across a shared context.
  - `tests/multiPanelDeletion.spec.ts` — a departed moving object is removed from **both**
    panels (this test fails on `main`, reproducing the stale box).
- `tsc --noEmit` and the production build are clean.
- Changed files have no new formatting / stable-rule lint violations.
- Built and verified locally via `yarn local-install`.

Bumps version to **1.0.1**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced multi-panel deletion handling so entities are added/removed consistently across panels when sharing the same converter.
* **Bug Fixes**
  * Improved visibility behavior: when category toggles are turned off, related entities are cleared reliably (including logical lanes) without leaving stale artifacts.
* **Documentation**
  * Updated architecture documentation to better describe multi-panel conversion and deletion tracking behavior.
* **Chores**
  * Bumped extension version to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->